### PR TITLE
Move vue to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/inouetakuya/vue-nl2br/issues"
   },
   "homepage": "https://github.com/inouetakuya/vue-nl2br#readme",
-  "dependencies": {
+  "peerDependencies": {
     "vue": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,10 +2212,6 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue@^2.0.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.3.3.tgz#d1eaa8fde5240735a4563e74f2c7fead9cbb064c"
-
 watchpack@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.3.1.tgz#7d8693907b28ce6013e7f3610aa2a1acf07dad87"


### PR DESCRIPTION
Fix [vue should be in peerDependencies · Issue #4 · inouetakuya/vue-nl2br](https://github.com/inouetakuya/vue-nl2br/issues/4)

https://docs.npmjs.com/files/package.json#peerdependencies
