### PR TITLE
Bump up NodeJS to v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Setup
         run: yarn install


### PR DESCRIPTION
https://github.com/inouetakuya/vue-nl2br/actions/runs/8396610271/job/22998334728?pr=255

> error @typescript-eslint/eslint-plugin@7.3.1: The engine "node" is incompatible with this module. Expected version "^18.18.0 || >=20.0.0". Got "16.20.2"