### PR TITLE
chore: Add deprecation notice and release v1.1.2 as the final version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.2](https://github.com/inouetakuya/vue-nl2br/compare/v1.1.1...v1.1.2) (2026-05-02)
+
+### Notes
+
+- This is the final release. The package is now deprecated and no longer maintained.
+- Use CSS `white-space: pre-wrap;` instead. See README for the migration guide.
+- No functional changes from v1.1.1 — only the deprecation notice in README and dependency updates.
+
 ## [1.1.1](https://github.com/inouetakuya/vue-nl2br/compare/v1.1.0...v1.1.1) (2022-06-11)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ In modern browsers, `vue-nl2br` can be replaced with a single CSS property: `whi
 ### Before
 
 ```html
-<nl2br tag="p" :text="`myLine1\nmyLine2`" />
+<nl2br tag="p" :text="`myLine1\nmyLine2`" class-name="foo bar" />
 ```
 
 ### After
 
 ```html
-<p style="white-space: pre-wrap;">{{ `myLine1\nmyLine2` }}</p>
+<p class="foo bar" style="white-space: pre-wrap;">{{ `myLine1\nmyLine2` }}</p>
 ```
 
-Or with a CSS class:
+Or with a CSS class (assuming `text` contains `\n` characters):
 
 ```css
 .nl2br {
@@ -41,6 +41,15 @@ Or with a CSS class:
 ### Why `pre-wrap` instead of `pre`?
 
 Historically, `white-space: pre;` was sometimes considered insufficient because it disables line wrapping (see [Issue #7](https://github.com/inouetakuya/vue-nl2br/issues/7)). `white-space: pre-wrap;` solves this by preserving line breaks while still allowing automatic wrapping for long lines.
+
+### Notes on subtle behavior differences
+
+`white-space: pre-wrap;` is not a strictly bit-for-bit replacement for `vue-nl2br`. Two minor differences are worth knowing:
+
+- **Whitespace preservation**: `pre-wrap` also preserves consecutive spaces and tabs in the source text. `vue-nl2br` only converts `\n` into `<br>` and lets the browser collapse other whitespace as usual.
+- **Copy/paste behavior**: text rendered with `<br>` and text rendered with `pre-wrap` may behave slightly differently when users copy the content out of the page.
+
+For the vast majority of use cases — displaying user-generated text with line breaks — these differences are negligible.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,50 @@
 # vue-nl2br
 
+> **DEPRECATED — No longer maintained**
+>
+> This package is no longer maintained. [Vue 2 reached End of Life on December 31, 2023](https://v2.vuejs.org/lts/), and modern CSS makes this component unnecessary in virtually all cases.
+>
+> **Use CSS `white-space: pre-wrap;` instead.** See the [Migration](#migration) section below.
+
 ![main workflow](https://github.com/inouetakuya/vue-nl2br/actions/workflows/main.yml/badge.svg)
 
 A vue component which turns new lines into line breaks.
 
-## Why not just use CSS?
+## Migration
 
-See [Why not just use CSS `white-space: pre;`? · Issue #7](https://github.com/inouetakuya/vue-nl2br/issues/7)
+In modern browsers, `vue-nl2br` can be replaced with a single CSS property: `white-space: pre-wrap;`.
+
+### Before
+
+```html
+<nl2br tag="p" :text="`myLine1\nmyLine2`" />
+```
+
+### After
+
+```html
+<p style="white-space: pre-wrap;">{{ `myLine1\nmyLine2` }}</p>
+```
+
+Or with a CSS class:
+
+```css
+.nl2br {
+  white-space: pre-wrap;
+}
+```
+
+```html
+<p class="nl2br">{{ text }}</p>
+```
+
+### Why `pre-wrap` instead of `pre`?
+
+Historically, `white-space: pre;` was sometimes considered insufficient because it disables line wrapping (see [Issue #7](https://github.com/inouetakuya/vue-nl2br/issues/7)). `white-space: pre-wrap;` solves this by preserving line breaks while still allowing automatic wrapping for long lines.
+
+---
+
+The sections below document the legacy API of `vue-nl2br` for existing users.
 
 ## Requirement
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-nl2br",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A vue component that turns new lines into line breaks.",
   "keywords": [
     "vue",


### PR DESCRIPTION
# 概要

`vue-nl2br` をクローズするにあたり、その第一歩として deprecation notice の追加と最終リリース v1.1.2 の準備を行います。

このパッケージが解決していた「データ中の改行を `<br>` として表示する」という課題は、現代の CSS の `white-space: pre-wrap;` で完全に置き換え可能です。また Vue 2 自体が 2023-12-31 に EOL を迎えており、本パッケージを今後メンテナンスし続ける合理的な理由はありません。

# 主な変更点

- README 冒頭に deprecation notice を追加し、Vue 2 EOL と CSS による代替が可能であることを明示
- README に Migration セクションを追加し、`white-space: pre-wrap;` への移行コード例（before / after）を掲載
- 移行先として `pre-wrap` を推奨する理由（Issue #7 で議論された折り返し問題の解決）を補足
- `package.json` の version を 1.1.1 から 1.1.2 に bump
- CHANGELOG に v1.1.2 のエントリを追加し、本リリースが最終版であり以降メンテナンスされない旨を明示

# 後続の作業（このプルリクエストには含めません）

このプルリクエストのマージ後、以下の作業を順に実施する予定です。

- v1.1.2 のタグ付けと `npm publish`
- `npm deprecate` の実行で `npm install` 時に警告が出るように設定
- 既存の Open Issues / Pull Requests をクローズ（#6、#21、#52、#117、#276、#309、#409、#419）
- Renovate 設定の停止
- GitHub リポジトリのアーカイブ化
