### PR TITLE
chore: Remove Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":timezone(Asia/Tokyo)"],
-  "schedule": ["after 5am and before 8am on saturday"]
-}


### PR DESCRIPTION
# 概要

`vue-nl2br` は v1.1.2 を最終リリースとして npm 上で deprecated になり、今後メンテナンスされません。依存パッケージの自動更新も不要となるため、Renovate の設定を削除します。

# 主な変更点

- `renovate.json` を削除し、Renovate による自動 PR 生成を停止

# 後続の作業

このプルリクエストのマージ後、以下を実施します。

- 既存の Open Issues / Pull Requests のクローズ
- GitHub リポジトリのアーカイブ化
